### PR TITLE
Fix - Moby-Dick isbn had incorrect check digit

### DIFF
--- a/mocks/mockData.ts
+++ b/mocks/mockData.ts
@@ -51,7 +51,7 @@ const mockData = [
         id: 7,
         title: 'Moby-Dick',
         author: 'Herman Melville',
-        isbn: '9781503280787',
+        isbn: '9781503280786',
         price: 14.99,
         availableStock: 7,
     },


### PR DESCRIPTION
Hello JP,

I have been doing the circle-frontend-challenge and ran the isbn for Moby-Dick through [my Ruby check digit generator](https://github.com/BrandonSayring/ruby-algo) and found that the check digit in the mock data is incorrect.

Original: 9781503280787
Actual isbn: 9781503280786